### PR TITLE
Add API version support to client

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 import os
 from dotenv import load_dotenv
-from pipedrive_client.client import PipedriveV2Client
+from pipedrive_client.client import PipedriveClient
 
 def main():
     # Load environment variables
@@ -9,16 +9,15 @@ def main():
     # Get credentials from environment variables
     api_token = os.getenv('PIPEDRIVE_API_KEY')
     company_domain = os.getenv('PIPEDRIVE_COMPANY_DOMAIN')
-    company_subdomain = os.getenv('PIPEDRIVE_COMPANY_SUBDOMAIN')
     
     if not api_token:
         raise ValueError("API Key Missing")
     
-    if not company_domain and not company_subdomain:
-        raise ValueError("Company Domain or Subdomain Missing. One is required.")
+    if not company_domain:
+        raise ValueError("Company domain missing")
     
     # Initialize Pipedrive client
-    client = PipedriveV2Client(api_token=api_token, company_domain=company_domain, company_subdomain=company_subdomain)
+    client = PipedriveClient(api_token=api_token, company_domain=company_domain)
     
     # Example usage (uncomment and modify as needed):
     deals = client.deals.get_details(123)
@@ -26,3 +25,4 @@ def main():
 
 if __name__ == '__main__':
     main()
+

--- a/pipedrive_client/__init__.py
+++ b/pipedrive_client/__init__.py
@@ -1,8 +1,6 @@
-"""
-Pipedrive API v2 Python Client
-"""
-from .client import PipedriveV2Client
+"""Pipedrive API Python Client."""
+from .client import PipedriveClient, PipedriveV2Client
 from .exceptions import PipedriveAPIError
 
-__all__ = ["PipedriveV2Client", "PipedriveAPIError"]
+__all__ = ["PipedriveClient", "PipedriveV2Client", "PipedriveAPIError"]
 __version__ = "0.1.0"

--- a/pipedrive_client/base.py
+++ b/pipedrive_client/base.py
@@ -1,11 +1,11 @@
 from typing import Optional, Dict, Any, TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from .client import PipedriveV2Client
+    from .client import PipedriveClient
 
 class BaseResource:
     """Base class for API resource endpoints."""
-    def __init__(self, client: 'PipedriveV2Client'):
+    def __init__(self, client: 'PipedriveClient'):
         self._client = client
 
     def _prepare_params(self, params: Optional[Dict[str, Any]]) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- add `PipedriveClient` with configurable `api_version`
- reuse single requests session
- handle non JSON responses in `_request`
- keep backwards compatible `PipedriveV2Client`
- update main usage example

## Testing
- `python -m py_compile pipedrive_client/client.py pipedrive_client/base.py pipedrive_client/__init__.py main.py`