### PR TITLE
Add models for organization and person fields

### DIFF
--- a/pipedrive_client/models/common.py
+++ b/pipedrive_client/models/common.py
@@ -67,3 +67,8 @@ class Attendee(BaseModel):
     is_organizer: Optional[int] = None # 0 or 1, V1 format still used? Check if boolean works.
     person_id: Optional[int] = None
     user_id: Optional[int] = None
+
+class FieldOption(BaseModel):
+    """Option item used with enum or set custom fields."""
+    id: Optional[int] = Field(None, description="Existing option ID")
+    label: str = Field(..., description="Displayed option label")

--- a/pipedrive_client/models/organization_fields.py
+++ b/pipedrive_client/models/organization_fields.py
@@ -1,0 +1,40 @@
+from typing import Optional, List
+from pydantic import BaseModel, Field
+from .common import FieldOption
+
+class GetOrganizationFieldsParams(BaseModel):
+    """Query parameters for GET /v1/organizationFields"""
+    start: Optional[int] = Field(None, description="Pagination start")
+    limit: Optional[int] = Field(None, description="Items shown per page")
+
+class OrganizationFieldOption(FieldOption):
+    """Option item used with enum or set field types."""
+
+class AddOrganizationFieldBody(BaseModel):
+    """Body parameters for POST /v1/organizationFields"""
+    name: str = Field(..., description="The name of the field")
+    field_type: str = Field(..., description="The type of the field")
+    options: Optional[List[OrganizationFieldOption]] = Field(
+        None,
+        description="Options for set or enum field types as sequential objects",
+    )
+    add_visible_flag: Optional[bool] = Field(
+        True,
+        description="Whether the field is available in the add new modal",
+    )
+
+class UpdateOrganizationFieldBody(BaseModel):
+    """Body parameters for PUT /v1/organizationFields/{id}"""
+    name: Optional[str] = Field(None, description="The name of the field")
+    options: Optional[List[OrganizationFieldOption]] = Field(
+        None,
+        description="Options for set or enum field types",
+    )
+    add_visible_flag: Optional[bool] = Field(
+        None,
+        description="Whether the field is available in the add new modal",
+    )
+
+class DeleteOrganizationFieldsParams(BaseModel):
+    """Query parameters for DELETE /v1/organizationFields"""
+    ids: str = Field(..., description="Comma-separated IDs to delete")

--- a/pipedrive_client/models/person_fields.py
+++ b/pipedrive_client/models/person_fields.py
@@ -1,0 +1,40 @@
+from typing import Optional, List
+from pydantic import BaseModel, Field
+from .common import FieldOption
+
+class GetPersonFieldsParams(BaseModel):
+    """Query parameters for GET /v1/personFields"""
+    start: Optional[int] = Field(None, description="Pagination start")
+    limit: Optional[int] = Field(None, description="Items shown per page")
+
+class PersonFieldOption(FieldOption):
+    """Option item used with enum or set field types."""
+
+class AddPersonFieldBody(BaseModel):
+    """Body parameters for POST /v1/personFields"""
+    name: str = Field(..., description="The name of the field")
+    field_type: str = Field(..., description="The type of the field")
+    options: Optional[List[PersonFieldOption]] = Field(
+        None,
+        description="Options for set or enum field types as sequential objects",
+    )
+    add_visible_flag: Optional[bool] = Field(
+        True,
+        description="Whether the field is available in the add new modal",
+    )
+
+class UpdatePersonFieldBody(BaseModel):
+    """Body parameters for PUT /v1/personFields/{id}"""
+    name: Optional[str] = Field(None, description="The name of the field")
+    options: Optional[List[PersonFieldOption]] = Field(
+        None,
+        description="Options for set or enum field types",
+    )
+    add_visible_flag: Optional[bool] = Field(
+        None,
+        description="Whether the field is available in the add new modal",
+    )
+
+class DeletePersonFieldsParams(BaseModel):
+    """Query parameters for DELETE /v1/personFields"""
+    ids: str = Field(..., description="Comma-separated IDs to delete")


### PR DESCRIPTION
## Summary
- model organization field endpoints
- model person field endpoints
- add shared FieldOption model

## Testing
- `python -m py_compile pipedrive_client/models/common.py pipedrive_client/models/organization_fields.py pipedrive_client/models/person_fields.py`