### PR TITLE
Add activity-related pydantic models

### DIFF
--- a/pipedrive_client/models/activities.py
+++ b/pipedrive_client/models/activities.py
@@ -2,48 +2,125 @@ from typing import Optional, List, Dict, Any, Union
 from pydantic import BaseModel, Field
 from .common import Address, Attendee, Participant, BaseCustomFieldsModel
 
+
 class ActivityCreateModel(BaseCustomFieldsModel):
+    """Body parameters for POST /api/v2/activities."""
+
     subject: str
     type: Optional[str] = None
     public_description: Optional[str] = None
     note: Optional[str] = None
-    due_date: Optional[str] = None # YYYY-MM-DD
-    due_time: Optional[str] = None # HH:MM
-    duration: Optional[str] = None # HH:MM
-    owner_id: Optional[int] = None # Renamed from user_id
+    due_date: Optional[str] = None  # YYYY-MM-DD
+    due_time: Optional[str] = None  # HH:MM
+    duration: Optional[str] = None  # HH:MM
+    owner_id: Optional[int] = None  # Renamed from user_id
     deal_id: Optional[int] = None
-    person_id: Optional[int] = Field(None, description="Read-only in v2, set via participants")
-    participants: Optional[List[Participant]] = None
+    lead_id: Optional[str] = None
+    person_id: Optional[int] = Field(
+        None, description="Read-only in v2, set via participants"
+    )
     org_id: Optional[int] = None
-    location: Optional[Union[str, Address]] = None # Can be simple string or structured Address
-    busy: Optional[bool] = Field(None, alias='busy_flag') # Alias for v1 compatibility if needed, prefer 'busy'
+    project_id: Optional[int] = None
+    participants: Optional[List[Participant]] = None
+    location: Optional[Union[str, Address]] = None
+    busy: Optional[bool] = Field(None, alias="busy_flag")
     attendees: Optional[List[Attendee]] = None
     done: Optional[bool] = None
-    # Add other relevant V2 fields based on documentation
+    priority: Optional[int] = None
 
     class Config:
         validate_by_name = True
-        # Pydantic v2: use_enum_values = True
+
 
 class ActivityUpdateModel(BaseCustomFieldsModel):
+    """Body parameters for PATCH /api/v2/activities/{id}."""
+
     subject: Optional[str] = None
     type: Optional[str] = None
     public_description: Optional[str] = None
     note: Optional[str] = None
-    due_date: Optional[str] = None # YYYY-MM-DD
-    due_time: Optional[str] = None # HH:MM
-    duration: Optional[str] = None # HH:MM
-    owner_id: Optional[int] = None # Renamed from user_id
+    due_date: Optional[str] = None  # YYYY-MM-DD
+    due_time: Optional[str] = None  # HH:MM
+    duration: Optional[str] = None  # HH:MM
+    owner_id: Optional[int] = None  # Renamed from user_id
     deal_id: Optional[int] = None
-    person_id: Optional[int] = Field(None, description="Read-only in v2, set via participants")
-    participants: Optional[List[Participant]] = None
+    lead_id: Optional[str] = None
+    person_id: Optional[int] = Field(
+        None, description="Read-only in v2, set via participants"
+    )
     org_id: Optional[int] = None
-    location: Optional[Union[str, Address]] = None # Can be simple string or structured Address
-    busy: Optional[bool] = Field(None, alias='busy_flag')
+    project_id: Optional[int] = None
+    participants: Optional[List[Participant]] = None
+    location: Optional[Union[str, Address]] = None
+    busy: Optional[bool] = Field(None, alias="busy_flag")
     attendees: Optional[List[Attendee]] = None
     done: Optional[bool] = None
-    # Add other relevant V2 fields based on documentation
+    priority: Optional[int] = None
 
     class Config:
         validate_by_name = True
-        # Pydantic v2: use_enum_values = True
+
+
+class GetActivitiesParams(BaseModel):
+    """Query parameters for GET /api/v2/activities."""
+
+    filter_id: Optional[int] = Field(
+        None,
+        description="Only activities matching the specified filter are returned",
+    )
+    ids: Optional[str] = Field(
+        None,
+        description="Comma-separated list of up to 100 activity IDs to fetch",
+    )
+    owner_id: Optional[int] = Field(
+        None,
+        description="Only activities owned by the specified user are returned",
+    )
+    deal_id: Optional[int] = Field(
+        None, description="Only activities linked to the specified deal"
+    )
+    lead_id: Optional[str] = Field(
+        None, description="Only activities linked to the specified lead"
+    )
+    person_id: Optional[int] = Field(
+        None,
+        description="Only activities whose primary participant is the given person",
+    )
+    org_id: Optional[int] = Field(
+        None, description="Only activities linked to the specified organization"
+    )
+    done: Optional[bool] = Field(
+        None, description="Whether the activity is done"
+    )
+    updated_since: Optional[str] = Field(
+        None,
+        description="Return activities with update_time >= this time (RFC3339)",
+    )
+    updated_until: Optional[str] = Field(
+        None,
+        description="Return activities with update_time < this time (RFC3339)",
+    )
+    sort_by: Optional[str] = Field(
+        None,
+        description="Field to sort by: id, update_time, add_time, due_date",
+    )
+    sort_direction: Optional[str] = Field(
+        None, description="Sorting direction, asc or desc"
+    )
+    include_fields: Optional[str] = Field(
+        None, description="Comma separated additional fields to include"
+    )
+    limit: Optional[int] = Field(
+        None, description="Number of items to return (max 500)"
+    )
+    cursor: Optional[str] = Field(
+        None, description="Pagination cursor for next page"
+    )
+
+
+class GetActivityParams(BaseModel):
+    """Query parameters for GET /api/v2/activities/{id}."""
+
+    include_fields: Optional[str] = Field(
+        None, description="Comma separated additional fields to include"
+    )

--- a/pipedrive_client/models/activity_fields.py
+++ b/pipedrive_client/models/activity_fields.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel
+
+
+class GetActivityFieldsParams(BaseModel):
+    """Query parameters for GET /v1/activityFields."""
+
+    pass

--- a/pipedrive_client/models/activity_types.py
+++ b/pipedrive_client/models/activity_types.py
@@ -1,0 +1,35 @@
+from typing import Optional
+from pydantic import BaseModel, Field
+
+
+class ActivityTypeCreateModel(BaseModel):
+    """Body parameters for POST /v1/activityTypes."""
+
+    name: str = Field(..., description="The name of the activity type")
+    icon_key: str = Field(..., description="Icon graphic representing the type")
+    color: Optional[str] = Field(
+        None,
+        description="Designated color in HEX format, e.g. 'FFFFFF'",
+    )
+
+
+class ActivityTypeUpdateModel(BaseModel):
+    """Body parameters for PUT /v1/activityTypes/{id}."""
+
+    name: Optional[str] = Field(None, description="The name of the activity type")
+    icon_key: Optional[str] = Field(
+        None, description="Icon graphic representing the type"
+    )
+    color: Optional[str] = Field(
+        None, description="Designated color in HEX format"
+    )
+    order_nr: Optional[int] = Field(
+        None,
+        description="Order number used to sort activity types in selections",
+    )
+
+
+class DeleteActivityTypesParams(BaseModel):
+    """Query parameters for DELETE /v1/activityTypes."""
+
+    ids: str = Field(..., description="Comma-separated activity type IDs")


### PR DESCRIPTION
## Summary
- add query models for activities
- add models for activity types and fields

## Testing
- `python -m compileall -q pipedrive_client`