### PR TITLE
Add Pydantic models for more API areas

### DIFF
--- a/pipedrive_client/models/__init__.py
+++ b/pipedrive_client/models/__init__.py
@@ -1,3 +1,57 @@
 # Pipedrive API v2 Models
 # Expose models if needed, or just use for internal type hinting
 
+from .filters import FilterCreateModel, FilterUpdateModel, GetFiltersParams, DeleteFiltersParams
+from .goals import (
+    GoalCreateModel,
+    GoalUpdateModel,
+    FindGoalsParams,
+    GoalResultParams,
+    GoalTypeNameEnum,
+    GoalAssigneeTypeEnum,
+    GoalTrackingMetricEnum,
+    GoalIntervalEnum,
+)
+from .leads import (
+    LeadCreateModel,
+    LeadUpdateModel,
+    GetLeadsParams,
+    SearchLeadsParams,
+    ConvertLeadToDealBody,
+)
+from .notes import (
+    NoteCreateModel,
+    NoteUpdateModel,
+    GetNotesParams,
+    CommentCreateModel,
+    CommentUpdateModel,
+)
+from .webhooks import WebhookCreateModel, EventActionEnum, EventObjectEnum
+
+__all__ = [
+    "FilterCreateModel",
+    "FilterUpdateModel",
+    "GetFiltersParams",
+    "DeleteFiltersParams",
+    "GoalCreateModel",
+    "GoalUpdateModel",
+    "FindGoalsParams",
+    "GoalResultParams",
+    "GoalTypeNameEnum",
+    "GoalAssigneeTypeEnum",
+    "GoalTrackingMetricEnum",
+    "GoalIntervalEnum",
+    "LeadCreateModel",
+    "LeadUpdateModel",
+    "GetLeadsParams",
+    "SearchLeadsParams",
+    "ConvertLeadToDealBody",
+    "NoteCreateModel",
+    "NoteUpdateModel",
+    "GetNotesParams",
+    "CommentCreateModel",
+    "CommentUpdateModel",
+    "WebhookCreateModel",
+    "EventActionEnum",
+    "EventObjectEnum",
+]

--- a/pipedrive_client/models/filters.py
+++ b/pipedrive_client/models/filters.py
@@ -1,0 +1,41 @@
+from enum import Enum
+from typing import Optional
+from pydantic import BaseModel, Field
+
+class FilterTypeEnum(str, Enum):
+    deals = "deals"
+    leads = "leads"
+    org = "org"
+    people = "people"
+    products = "products"
+    activity = "activity"
+    projects = "projects"
+
+class GetFiltersParams(BaseModel):
+    """Query parameters for GET /v1/filters"""
+
+    type: Optional[FilterTypeEnum] = Field(
+        None, description="The types of filters to fetch"
+    )
+
+class FilterCreateModel(BaseModel):
+    """Body parameters for POST /v1/filters"""
+
+    name: str = Field(..., description="The name of the filter")
+    conditions: dict = Field(
+        ..., description="The conditions of the filter as a JSON object"
+    )
+    type: FilterTypeEnum = Field(..., description="The type of filter to create")
+
+class FilterUpdateModel(BaseModel):
+    """Body parameters for PUT /v1/filters/{id}"""
+
+    name: Optional[str] = Field(None, description="The name of the filter")
+    conditions: Optional[dict] = Field(
+        None, description="The conditions of the filter as a JSON object"
+    )
+
+class DeleteFiltersParams(BaseModel):
+    """Query parameters for DELETE /v1/filters"""
+
+    ids: str = Field(..., description="Comma-separated filter IDs to delete")

--- a/pipedrive_client/models/goals.py
+++ b/pipedrive_client/models/goals.py
@@ -1,0 +1,110 @@
+from enum import Enum
+from typing import Optional, List, Dict, Any
+from pydantic import BaseModel, Field
+
+class GoalTypeNameEnum(str, Enum):
+    deals_won = "deals_won"
+    deals_progressed = "deals_progressed"
+    activities_completed = "activities_completed"
+    activities_added = "activities_added"
+    deals_started = "deals_started"
+    revenue_forecast = "revenue_forecast"
+
+class GoalAssigneeTypeEnum(str, Enum):
+    person = "person"
+    company = "company"
+    team = "team"
+
+class GoalTrackingMetricEnum(str, Enum):
+    quantity = "quantity"
+    sum = "sum"
+
+class GoalIntervalEnum(str, Enum):
+    weekly = "weekly"
+    monthly = "monthly"
+    quarterly = "quarterly"
+    yearly = "yearly"
+
+class GoalAssignee(BaseModel):
+    id: int = Field(..., description="ID of the assignee")
+    type: GoalAssigneeTypeEnum = Field(..., description="Type of the assignee")
+
+class GoalType(BaseModel):
+    name: GoalTypeNameEnum = Field(..., description="Type of the goal")
+    params: Optional[Dict[str, Any]] = Field(
+        None,
+        description="Additional parameters like pipeline_id, stage_id or activity_type_id",
+    )
+
+class ExpectedOutcome(BaseModel):
+    target: float = Field(..., description="Numeric value of the outcome")
+    tracking_metric: GoalTrackingMetricEnum = Field(
+        ..., description="Tracking metric of the outcome"
+    )
+    currency_id: Optional[int] = Field(
+        None,
+        description="Currency ID, used when tracking_metric is 'sum'",
+    )
+
+class GoalDuration(BaseModel):
+    start: str = Field(..., description="Start date YYYY-MM-DD")
+    end: Optional[str] = Field(None, description="End date YYYY-MM-DD or null")
+
+class FindGoalsParams(BaseModel):
+    """Query parameters for GET /v1/goals/find"""
+
+    type_name: Optional[GoalTypeNameEnum] = Field(None, alias="type.name")
+    title: Optional[str] = None
+    is_active: Optional[bool] = None
+    assignee_id: Optional[int] = Field(None, alias="assignee.id")
+    assignee_type: Optional[GoalAssigneeTypeEnum] = Field(
+        None, alias="assignee.type"
+    )
+    expected_outcome_target: Optional[float] = Field(
+        None, alias="expected_outcome.target"
+    )
+    expected_outcome_tracking_metric: Optional[GoalTrackingMetricEnum] = Field(
+        None, alias="expected_outcome.tracking_metric"
+    )
+    expected_outcome_currency_id: Optional[int] = Field(
+        None, alias="expected_outcome.currency_id"
+    )
+    type_params_pipeline_id: Optional[List[int]] = Field(
+        None, alias="type.params.pipeline_id"
+    )
+    type_params_stage_id: Optional[int] = Field(
+        None, alias="type.params.stage_id"
+    )
+    type_params_activity_type_id: Optional[List[int]] = Field(
+        None, alias="type.params.activity_type_id"
+    )
+    period_start: Optional[str] = Field(None, alias="period.start")
+    period_end: Optional[str] = Field(None, alias="period.end")
+
+class GoalCreateModel(BaseModel):
+    """Body parameters for POST /v1/goals"""
+
+    title: str = Field(..., description="Title of the goal")
+    assignee: GoalAssignee = Field(..., description="Goal assignee")
+    type: GoalType = Field(..., description="Goal type definition")
+    expected_outcome: ExpectedOutcome = Field(
+        ..., description="Expected outcome of the goal"
+    )
+    duration: GoalDuration = Field(..., description="Goal duration")
+    interval: GoalIntervalEnum = Field(..., description="Goal interval")
+
+class GoalUpdateModel(BaseModel):
+    """Body parameters for PUT /v1/goals/{id}"""
+
+    title: Optional[str] = None
+    assignee: Optional[GoalAssignee] = None
+    type: Optional[GoalType] = None
+    expected_outcome: Optional[ExpectedOutcome] = None
+    duration: Optional[GoalDuration] = None
+    interval: Optional[GoalIntervalEnum] = None
+
+class GoalResultParams(BaseModel):
+    """Query parameters for GET /v1/goals/{id}/results"""
+
+    period_start: str = Field(..., alias="period.start")
+    period_end: str = Field(..., alias="period.end")

--- a/pipedrive_client/models/leads.py
+++ b/pipedrive_client/models/leads.py
@@ -1,0 +1,100 @@
+from typing import Optional, List
+from pydantic import BaseModel, Field
+from .common import MonetaryValue
+
+class GetLeadsParams(BaseModel):
+    """Query parameters for GET /v1/leads"""
+
+    limit: Optional[int] = Field(None, description="Items per page")
+    start: Optional[int] = Field(None, description="Pagination start position")
+    owner_id: Optional[int] = Field(None, description="Filter by owner user ID")
+    person_id: Optional[int] = Field(None, description="Filter by person ID")
+    organization_id: Optional[int] = Field(
+        None, description="Filter by organization ID"
+    )
+    filter_id: Optional[int] = Field(None, description="ID of the filter to use")
+    sort: Optional[str] = Field(
+        None,
+        description="Field name and sorting mode, e.g. 'add_time DESC'",
+    )
+
+class LeadValue(MonetaryValue):
+    """Potential value of the lead."""
+
+class LeadCreateModel(BaseModel):
+    """Body parameters for POST /v1/leads"""
+
+    title: str = Field(..., description="Name of the lead")
+    owner_id: Optional[int] = Field(
+        None,
+        description="ID of the user that will own the lead",
+    )
+    label_ids: Optional[List[int]] = Field(
+        None, description="IDs of labels associated with the lead"
+    )
+    person_id: Optional[int] = Field(
+        None, description="ID of a person linked to the lead"
+    )
+    organization_id: Optional[int] = Field(
+        None, description="ID of an organization linked to the lead"
+    )
+    value: Optional[LeadValue] = Field(
+        None, description="Potential value of the lead"
+    )
+    expected_close_date: Optional[str] = Field(
+        None, description="Expected close date YYYY-MM-DD"
+    )
+    visible_to: Optional[int] = Field(
+        None, description="Visibility of the lead"
+    )
+    was_seen: Optional[bool] = Field(
+        None, description="Flag indicating whether the lead was seen"
+    )
+    origin_id: Optional[str] = Field(
+        None, description="Optional ID to distinguish the origin of the lead"
+    )
+    channel: Optional[int] = Field(
+        None, description="Marketing channel ID"
+    )
+    channel_id: Optional[str] = Field(
+        None, description="Optional ID to distinguish the channel"
+    )
+
+class LeadUpdateModel(BaseModel):
+    """Body parameters for PATCH /v1/leads/{id}"""
+
+    title: Optional[str] = None
+    owner_id: Optional[int] = None
+    label_ids: Optional[List[int]] = None
+    person_id: Optional[int] = None
+    organization_id: Optional[int] = None
+    is_archived: Optional[bool] = None
+    value: Optional[LeadValue] = None
+    expected_close_date: Optional[str] = None
+    visible_to: Optional[int] = None
+    was_seen: Optional[bool] = None
+    channel: Optional[int] = None
+    channel_id: Optional[str] = None
+    origin_id: Optional[str] = None
+
+class ConvertLeadToDealBody(BaseModel):
+    """Body parameters for POST /api/v2/leads/{id}/convert/deal"""
+
+    stage_id: Optional[int] = Field(
+        None, description="ID of the stage the created deal will be added to"
+    )
+    pipeline_id: Optional[int] = Field(
+        None,
+        description="ID of the pipeline the created deal will belong to",
+    )
+
+class SearchLeadsParams(BaseModel):
+    """Query parameters for GET /v1/leads/search"""
+
+    term: str = Field(..., description="Search term")
+    person_id: Optional[int] = Field(None, description="Filter by person ID")
+    organization_id: Optional[int] = Field(
+        None, description="Filter by organization ID"
+    )
+    limit: Optional[int] = Field(None, description="Items per page")
+    start: Optional[int] = Field(None, description="Pagination start position")

--- a/pipedrive_client/models/notes.py
+++ b/pipedrive_client/models/notes.py
@@ -1,0 +1,93 @@
+from typing import Optional
+from pydantic import BaseModel, Field
+
+class GetNotesParams(BaseModel):
+    """Query parameters for GET /v1/notes"""
+
+    user_id: Optional[int] = Field(None, description="Filter by user ID")
+    lead_id: Optional[str] = Field(None, description="Filter by lead ID")
+    deal_id: Optional[int] = Field(None, description="Filter by deal ID")
+    person_id: Optional[int] = Field(None, description="Filter by person ID")
+    org_id: Optional[int] = Field(None, description="Filter by organization ID")
+    project_id: Optional[int] = Field(None, description="Filter by project ID")
+    start: Optional[int] = Field(None, description="Pagination start")
+    limit: Optional[int] = Field(None, description="Items per page")
+    sort: Optional[str] = Field(
+        None,
+        description="Field names and sorting mode, e.g. 'add_time DESC'",
+    )
+    start_date: Optional[str] = Field(None, description="Filter notes from date")
+    end_date: Optional[str] = Field(None, description="Filter notes until date")
+    pinned_to_lead_flag: Optional[int] = Field(
+        None, description="Filter by note to lead pinning state"
+    )
+    pinned_to_deal_flag: Optional[int] = Field(
+        None, description="Filter by note to deal pinning state"
+    )
+    pinned_to_organization_flag: Optional[int] = Field(
+        None, description="Filter by note to organization pinning state"
+    )
+    pinned_to_person_flag: Optional[int] = Field(
+        None, description="Filter by note to person pinning state"
+    )
+    pinned_to_project_flag: Optional[int] = Field(
+        None, description="Filter by note to project pinning state"
+    )
+
+class NoteCreateModel(BaseModel):
+    """Body parameters for POST /v1/notes"""
+
+    content: str = Field(..., description="Content of the note in HTML")
+    lead_id: Optional[str] = Field(
+        None, description="ID of the lead the note is attached to"
+    )
+    deal_id: Optional[int] = Field(
+        None, description="ID of the deal the note is attached to"
+    )
+    person_id: Optional[int] = Field(
+        None, description="ID of the person the note is attached to"
+    )
+    org_id: Optional[int] = Field(
+        None, description="ID of the organization the note is attached to"
+    )
+    project_id: Optional[int] = Field(
+        None, description="ID of the project the note is attached to"
+    )
+    user_id: Optional[int] = Field(
+        None, description="ID of the user marked as author"
+    )
+    add_time: Optional[str] = Field(
+        None, description="Optional creation time YYYY-MM-DD HH:MM:SS"
+    )
+    pinned_to_lead_flag: Optional[int] = None
+    pinned_to_deal_flag: Optional[int] = None
+    pinned_to_organization_flag: Optional[int] = None
+    pinned_to_person_flag: Optional[int] = None
+    pinned_to_project_flag: Optional[int] = None
+
+class NoteUpdateModel(BaseModel):
+    """Body parameters for PUT /v1/notes/{id}"""
+
+    content: Optional[str] = None
+    lead_id: Optional[str] = None
+    deal_id: Optional[int] = None
+    person_id: Optional[int] = None
+    org_id: Optional[int] = None
+    project_id: Optional[int] = None
+    user_id: Optional[int] = None
+    add_time: Optional[str] = None
+    pinned_to_lead_flag: Optional[int] = None
+    pinned_to_deal_flag: Optional[int] = None
+    pinned_to_organization_flag: Optional[int] = None
+    pinned_to_person_flag: Optional[int] = None
+    pinned_to_project_flag: Optional[int] = None
+
+class CommentCreateModel(BaseModel):
+    """Body parameters for POST /v1/notes/{id}/comments"""
+
+    content: str = Field(..., description="Content of the comment in HTML")
+
+class CommentUpdateModel(BaseModel):
+    """Body parameters for PUT /v1/notes/{id}/comments/{commentId}"""
+
+    content: str = Field(..., description="Content of the comment in HTML")

--- a/pipedrive_client/models/webhooks.py
+++ b/pipedrive_client/models/webhooks.py
@@ -1,0 +1,48 @@
+from enum import Enum
+from typing import Optional
+from pydantic import BaseModel, Field
+
+class EventActionEnum(str, Enum):
+    create = "create"
+    change = "change"
+    delete = "delete"
+    all = "*"
+
+class EventObjectEnum(str, Enum):
+    activity = "activity"
+    deal = "deal"
+    lead = "lead"
+    note = "note"
+    organization = "organization"
+    person = "person"
+    pipeline = "pipeline"
+    product = "product"
+    stage = "stage"
+    user = "user"
+    all = "*"
+
+class WebhookCreateModel(BaseModel):
+    """Body parameters for POST /v1/webhooks"""
+
+    subscription_url: str = Field(
+        ..., description="Public URL where notifications will be sent"
+    )
+    event_action: EventActionEnum = Field(
+        ..., description="Type of action to receive notifications about"
+    )
+    event_object: EventObjectEnum = Field(
+        ..., description="Type of object to receive notifications about"
+    )
+    user_id: Optional[int] = Field(
+        None,
+        description="User ID that authorizes the webhook (defaults to current user)",
+    )
+    http_auth_user: Optional[str] = Field(
+        None, description="HTTP auth username for the subscription URL"
+    )
+    http_auth_password: Optional[str] = Field(
+        None, description="HTTP auth password for the subscription URL"
+    )
+    version: Optional[str] = Field(
+        "2.0", description="Webhook version"
+    )


### PR DESCRIPTION
## Summary
- add new Pydantic models covering Filters, Goals, Leads, Notes and Webhooks
- export the new models via `pipedrive_client.models`

## Testing
- `git commit -m "Add models for filters, goals, leads, notes and webhooks"`